### PR TITLE
add missing default fields to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,5 +14,18 @@
   "license": "MIT",
   "dependencies": {
     "gaze": "~0.4.3"
-  }
+  },
+  "main": "index.js",
+  "devDependencies": {},
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/Qard/onchange.git"
+  },
+  "bugs": {
+    "url": "https://github.com/Qard/onchange/issues"
+  },
+  "homepage": "https://github.com/Qard/onchange"
 }


### PR DESCRIPTION
i just cloned and ran `npm init` and held down enter. this is mostly to add the repo link to npm (theres no way to get to this repo from https://www.npmjs.org/package/onchange at the moment)
