### PR TITLE
Print usage string

### DIFF
--- a/index.js
+++ b/index.js
@@ -11,6 +11,12 @@ var pwd = process.cwd()
 var matches = []
 var arg
 
+// Print usage info
+if (!process.argv.length || process.argv == '--help') {
+  console.log('Usage:  onchange [file]... -- <command> [arg]...');
+  process.exit();
+}
+
 // Shift everything before -- into match list
 while ((arg = process.argv.shift()) !== '--') {
   matches.push(arg)


### PR DESCRIPTION
Print usage string on `--help` and when no arguments are passed.

Current behavior:
```
$ onchange --help
FATAL ERROR: JS Allocation failed - process out of memory
```