### PR TITLE
Use debug module for logging

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,6 +1,8 @@
 #!/usr/bin/env node
 var spawn = require('cross-spawn').spawn
 var gaze = require('gaze')
+var debug = require('debug')('onchange')
+var log = debug;
 
 // Shift node and script name out of argv
 process.argv.shift()
@@ -27,7 +29,7 @@ var command = process.argv.shift()
 var args = process.argv
 
 // Notify the user what they are watching
-console.log('watching', matches.join(', '))
+log('watching', matches.join(', '))
 
 // Ignore node_modules folders, as they eat CPU like crazy
 matches.push('!**/node_modules/**')
@@ -43,7 +45,7 @@ gaze(matches, function () {
     running = true;
 
     // Log the event type and the file affected
-    console.log(type, file.replace(pwd, ''))
+    log(type, file.replace(pwd, ''))
 
     // Run the command and forward output
     var proc = spawn(command, args, {
@@ -52,7 +54,7 @@ gaze(matches, function () {
 
     // Log the result and unlock
     proc.on('close', function (code) {
-      console.log('completed with code', code)
+      log('completed with code', code)
       running = false;
     })
   })

--- a/index.js
+++ b/index.js
@@ -29,7 +29,7 @@ var command = process.argv.shift()
 var args = process.argv
 
 // Notify the user what they are watching
-log('watching', matches.join(', '))
+log('watching ' + matches.join(', '))
 
 // Ignore node_modules folders, as they eat CPU like crazy
 matches.push('!**/node_modules/**')
@@ -45,7 +45,7 @@ gaze(matches, function () {
     running = true;
 
     // Log the event type and the file affected
-    log(type, file.replace(pwd, ''))
+    log(type + ' ' + file.replace(pwd, ''))
 
     // Run the command and forward output
     var proc = spawn(command, args, {
@@ -54,7 +54,7 @@ gaze(matches, function () {
 
     // Log the result and unlock
     proc.on('close', function (code) {
-      log('completed with code', code)
+      log('completed with code ' + code)
       running = false;
     })
   })

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
   "license": "MIT",
   "dependencies": {
     "cross-spawn": "~0.2.3",
+    "debug": "~2.1.1",
     "gaze": "~0.5.1"
   },
   "main": "index.js",


### PR DESCRIPTION
There are pros/cons with this approach: while it does come with simple timestamp and coloring for free, you need DEBUG=onchange for them to show up, so default behaviour is changed (I left the `Usage` output untouched though).

I am using this module mostly for `npm run` command during continuous development, without coloring and timestamp it's difficult to trace problems. Plus my other modules like https://github.com/bitinn/wiper all use `debug`, so I am totally biased.

Still, consider this pull request as a suggestion for features :)