### PR TITLE
No need for single quote in readme doc

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Use glob patterns to watch file sets and run a command when anything is added, c
 
 ## Usage
     
-    onchange 'app/**/*.js' 'test/**/*.js' -- npm test
+    onchange app/**/*.js test/**/*.js -- npm test
 
 You can match as many glob patterns as you like, just put the command you want to run after the -- and it will run any time a file matching any of the globs is added changed or deleted.
 


### PR DESCRIPTION
I mean there are literally no reasons for using single quote in this example, right?

(I know you are going to release a whole new version, but this resolve complains like #10)