### PR TITLE
Allow optional file watcher (use gaze or chokidar)

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,11 +6,13 @@ Use glob patterns to watch file sets and run a command when anything is added, c
 
     npm install onchange
 
+Then either `npm install chokidar` or `npm install gaze` to enable file watcher capability.
+
 ## Usage
     
     onchange 'app/**/*.js' 'test/**/*.js' -- npm test
 
-You can match as many glob patterns as you like, just put the command you want to run after the -- and it will run any time a file matching any of the globs is added changed or deleted.
+You can match as many glob patterns as you like, just put the command you want to run after the -- and it will run any time a file matching any of the globs is added changed or deleted. Note that you can use `\` to escape `*` as well.
 
 ---
 

--- a/index.js
+++ b/index.js
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 var spawn = require('cross-spawn').spawn
 var log = require('debug')('onchange')
-var chokidar = require('chokidar')
+var watch = require('gaze')
 
 // Parse argv with minimist...it's easier this way.
 var argv = require('minimist')(process.argv.slice(2), {
@@ -45,7 +45,8 @@ log('watching ' + matches.join(', '))
 matches.push('!**/node_modules/**')
 
 // Start watcher
-var watcher = chokidar.watch(matches)
+
+var watcher = watch(matches);
 watcher.on('ready', function () {
   var running = false
 

--- a/index.js
+++ b/index.js
@@ -1,7 +1,21 @@
 #!/usr/bin/env node
 var spawn = require('cross-spawn').spawn
 var log = require('debug')('onchange')
-var watch = require('gaze')
+
+try {
+  var chokidar = require('chokidar')
+} catch(e) {
+}
+
+try {
+  var gaze = require('gaze')
+} catch(e) {
+}
+
+if (!chokidar && !gaze) {
+  console.log('Please `npm install chokidar` or `npm install gaze` first')
+  return
+}
 
 // Parse argv with minimist...it's easier this way.
 var argv = require('minimist')(process.argv.slice(2), {
@@ -45,8 +59,13 @@ log('watching ' + matches.join(', '))
 matches.push('!**/node_modules/**')
 
 // Start watcher
+var watcher
+if (gaze) {
+  watcher = gaze(matches)
+} else {
+  watcher = chokidar.watch(matches)
+}
 
-var watcher = watch(matches);
 watcher.on('ready', function () {
   var running = false
 

--- a/package.json
+++ b/package.json
@@ -15,7 +15,6 @@
   "dependencies": {
     "cross-spawn": "~0.2.3",
     "debug": "~2.1.1",
-    "gaze": "~0.5.1",
     "minimist": "~1.1.0"
   },
   "main": "index.js",

--- a/package.json
+++ b/package.json
@@ -13,9 +13,9 @@
   },
   "license": "MIT",
   "dependencies": {
-    "chokidar": "~1.0.0-rc3",
     "cross-spawn": "~0.2.3",
     "debug": "~2.1.1",
+    "gaze": "~0.5.1",
     "minimist": "~1.1.0"
   },
   "main": "index.js",


### PR DESCRIPTION
This looks a bit crazy, but hear me out:

1. Every time you install chokidar, it rebuilds `fsevents` with node-gyp, it's a headache on windows and support for [iojs is currently missing](https://github.com/TooTallNate/node-gyp/pull/564).

2. I know chokidar is fast on OS X, but gaze made some trade-off to achieve better compatibility across platforms, which I am fine with.

3. Hopefully when [sane](https://github.com/amasad/sane) proves itself to be stable, we can use it as well (does look pretty promising.)

Decision is yours, I am using my branch at the moment because of iojs and I really don't want to touch node-gyp just for a file watcher...