### PR TITLE
Switch to use console.log for logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,9 +12,9 @@ Use glob patterns to watch file sets and run a command when anything is added, c
 
 You can match as many glob patterns as you like, just put the command you want to run after the -- and it will run any time a file matching any of the globs is added changed or deleted.
 
-And also, if you want a more verbose output, set the `DEBUG` environment variable to `onchange`. For example:
+If you want a more verbose output, include the '-d' flag. For Example:
 
-    DEBUG=onchange onchange 'app/**/*.js' 'test/**/*.js' -- npm test
+	onchange 'app/**/*.js' 'test/**/*.js' -d -- npm test
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -12,9 +12,9 @@ Use glob patterns to watch file sets and run a command when anything is added, c
 
 You can match as many glob patterns as you like, just put the command you want to run after the -- and it will run any time a file matching any of the globs is added changed or deleted.
 
-If you want a more verbose output, include the '-d' flag. For Example:
+If you want a more verbose output, include the '-v' flag. For Example:
 
-	onchange 'app/**/*.js' 'test/**/*.js' -d -- npm test
+	onchange 'app/**/*.js' 'test/**/*.js' -v -- npm test
 
 ---
 

--- a/cli.js
+++ b/cli.js
@@ -12,6 +12,8 @@ if ( ! argv._.length || argv.help) {
   process.exit()
 }
 
+var noise = argc.d
+
 // Setup some storage variables
 var arg
 var matches = argv._
@@ -33,4 +35,4 @@ var args = argv['--']
 var command = args.shift()
 
 // Start watcher
-onchange(matches, command, args)
+onchange(matches, command, args, noise)

--- a/cli.js
+++ b/cli.js
@@ -12,7 +12,7 @@ if ( ! argv._.length || argv.help) {
   process.exit()
 }
 
-var noise = argc.d
+var verbose = argv.v
 
 // Setup some storage variables
 var arg
@@ -35,4 +35,4 @@ var args = argv['--']
 var command = args.shift()
 
 // Start watcher
-onchange(matches, command, args, noise)
+onchange(matches, command, args, verbose)

--- a/index.js
+++ b/index.js
@@ -1,6 +1,5 @@
 var spawn = require('cross-spawn').spawn
 var chokidar = require('chokidar')
-var colors = require('colors')
 
 module.exports = function (matches, command, args, verbose) {
   var pwd = process.cwd()
@@ -12,7 +11,7 @@ module.exports = function (matches, command, args, verbose) {
 
   // Notify the user what they are watching
   var watching = 'watching ' + matches.join(', ')
-  log('onchange '.cyan + watching)
+  log('onchange ' + watching)
 
   // Ignore node_modules folders, as they eat CPU like crazy
   matches.push('!**/node_modules/**')
@@ -28,13 +27,13 @@ module.exports = function (matches, command, args, verbose) {
     // However, skip if the last run is still active.
     watcher.on('all', function (event, file) {
       if (running){
-        log("\n" + "onchange".white.bgBlack + " " + "WARN".black.bgYellow + " " + "Skipped ".red + "Last action still running.\n")
+        log("onchange: Skipped Last action still running.")
         return
       }
       running = true
 
       // Log the event and the file affected
-      log('onchange '.cyan+ event + ' to ' + file.replace(pwd, ''))
+      log(event + ' to ' + file.replace(pwd, ''))
 
       // Generate argument strings from templates
       var filtered = tmpls.map(function (tmpl) {
@@ -48,9 +47,9 @@ module.exports = function (matches, command, args, verbose) {
 
       // Log the result and unlock
       proc.on('close', function (code) {
-        log('\n' + 'onchange '.cyan + 'completed with code ' + code)
+        log('onchange: completed with code ' + code)
         running = false
-        log('\n' + 'onchange '.cyan + watching)
+        log('onchange ' + watching)
       })
     })
   })

--- a/index.js
+++ b/index.js
@@ -2,14 +2,17 @@ var spawn = require('cross-spawn').spawn
 var chokidar = require('chokidar')
 var colors = require('colors')
 
-module.exports = function (matches, command, args, noise) {
+module.exports = function (matches, command, args, verbose) {
   var pwd = process.cwd()
+
+  // Logging
+  function log(){
+    if (verbose) console.log.apply(console, arguments)
+  }
 
   // Notify the user what they are watching
   var watching = 'watching ' + matches.join(', ')
-  if (noise){
-    console.log('onchange '.cyan + watching)
-  }
+  log('onchange '.cyan + watching)
 
   // Ignore node_modules folders, as they eat CPU like crazy
   matches.push('!**/node_modules/**')
@@ -25,17 +28,13 @@ module.exports = function (matches, command, args, noise) {
     // However, skip if the last run is still active.
     watcher.on('all', function (event, file) {
       if (running){
-        if (noise){
-          console.log("\n" + "onchange".white.bgBlack + " " + "WARN".black.bgYellow + " " + "Skipped ".red + "Last action still running.\n")
-        }
+        log("\n" + "onchange".white.bgBlack + " " + "WARN".black.bgYellow + " " + "Skipped ".red + "Last action still running.\n")
         return
       }
       running = true
 
       // Log the event and the file affected
-      if (noise){
-        console.log(event + ' to ' + file.replace(pwd, ''))
-      }
+      log('onchange '.cyan+ event + ' to ' + file.replace(pwd, ''))
 
       // Generate argument strings from templates
       var filtered = tmpls.map(function (tmpl) {
@@ -49,13 +48,9 @@ module.exports = function (matches, command, args, noise) {
 
       // Log the result and unlock
       proc.on('close', function (code) {
-        if (noise){
-          console.log('\n' + 'onchange '.cyan + 'completed with code ' + code)
-        }
+        log('\n' + 'onchange '.cyan + 'completed with code ' + code)
         running = false
-        if (noise){
-          console.log('\n' + 'onchange '.cyan + watching)
-        }
+        log('\n' + 'onchange '.cyan + watching)
       })
     })
   })

--- a/package.json
+++ b/package.json
@@ -15,8 +15,7 @@
   "dependencies": {
     "chokidar": "~1.0.0",
     "cross-spawn": "~0.2.3",
-    "minimist": "~1.1.0",
-    "colors": "~1.1.2"
+    "minimist": "~1.1.0"
   },
   "main": "index.js",
   "devDependencies": {},

--- a/package.json
+++ b/package.json
@@ -15,8 +15,8 @@
   "dependencies": {
     "chokidar": "~1.0.0",
     "cross-spawn": "~0.2.3",
-    "debug": "~2.1.1",
-    "minimist": "~1.1.0"
+    "minimist": "~1.1.0",
+    "colors": "~1.1.2"
   },
   "main": "index.js",
   "devDependencies": {},


### PR DESCRIPTION
I know at some point you changed to use DEBUG module for logging but hear me out here. Personally I feel the "DEBUG=onchange" step feels a bit too unnatural, even with build tools, and might seem weird to new users. DEBUG is meant to be a debug module after all. 

By using the "colors" module the same effect with colours can be achieve and the only thing that is lost is the timestamp.

Default is still kept as quiet mode. So instead of "DEBUG=onchange" we can just use minimist parsing that you already used to look for a "-d" flag which will enable noisy mode.

Naturally, it's your call though.  : )