### PR TITLE
Update cross-spawn dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   "dependencies": {
     "arrify": "~1.0.1",
     "chokidar": "~1.4.3",
-    "cross-spawn": "~2.1.5",
+    "cross-spawn": "~4.0.0",
     "minimist": "~1.2.0"
   },
   "main": "index.js",


### PR DESCRIPTION
Gets rid of an npm deprecation warning at install time for cross-spawn-async.

All tests seemed to pass (`npm test` returned status 0), but there was no output. Maybe that's expected?