### PR TITLE
Add argument to disable automatic node_module exclusion (#39).

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,12 @@ To exclude matches:
 onchange '**/*.ts' -e 'dist/**/*.js' -- tslint
 ```
 
+By default, all files in the `node_modules` directory will be excluded. To override this use `--allow-node-modules` or pass any exclude argument:
+
+```sh
+onchange 'node_modules/myWatchedPackage/**/*.js' --allow-node-modules -- npm run docs
+```
+
 To wait for the current process to exit between restarts:
 
 ```sh

--- a/cli.js
+++ b/cli.js
@@ -5,7 +5,7 @@ var arrify = require('arrify')
 // Parse argv with minimist...it's easier this way.
 var argv = require('minimist')(process.argv.slice(2), {
   '--': true,
-  boolean: ['v', 'i', 'w'],
+  boolean: ['v', 'i', 'w', 'allow-node-modules'],
   string: ['e', 'c', 'killSignal'],
   alias: {
     verbose: ['v'],
@@ -30,7 +30,7 @@ var matches = argv._.slice()
 var exclude = arrify(argv.exclude)
 
 // Ignore node_modules folders, as they eat CPU like crazy
-if (exclude.length === 0) {
+if (exclude.length === 0 && argv['allow-node-modules']) {
   exclude.push('**/node_modules/**')
 }
 


### PR DESCRIPTION
Couldn't get `--no-exclude` to work properly. It looks like minimist was not picking it up in argv unless I added it to the boolean list. But minimist alway treat `--no-XXX` as `false` (https://github.com/substack/minimist/issues/54). Decided to use `--allow-node-module` instead of `--no-exclude=true`. Also, think its a bit more descriptive, especially if you try to pass `--no-exclude` at the same time you pass an exclusion.