### PR TITLE
Enable support for '--filter'

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,27 @@ onchange 'src/**/*.js' -o '> .change' -- echo '{{event}} to {{changed}}'
 
 **P.S.** When a command is used with `--outpipe`, the `stdout` from the command will be piped into `outpipe`.
 
+### Filter (`-f`, `--filter`)
+
+By default, onchange watch for all events from [chokidar](https://github.com/paulmillr/chokidar#methods--events). Use
+this option to watch only for events you need:
+
+```sh
+onchange '**/*.js' -f add -f change -- npm start
+```
+
+You can separate events to listen with comas if you prefer:
+
+```sh
+onchange '**/*.js' -f add,change -- npm start
+```
+
+Or with spaces:
+
+```sh
+onchange '**/*.js' -f 'add change' -- npm start
+```
+
 ## TypeScript
 
 Includes [types](index.d.ts) for TypeScript users.

--- a/cli.js
+++ b/cli.js
@@ -48,10 +48,6 @@ var options = {
   filter: argv.filter && (Array.isArray(argv.filter) ? argv.filter : argv.filter.split(/\W+/))
 }
 
-if (argv.filter) {
-    options.filter = Array.isArray(argv.filter) ? argv.filter : argv.filter.split(/\W+/);
-}
-
 if (!command && !options.outpipe) {
   console.error('Remember to pass the command after "--":')
   console.error('  onchange \'**/*.js\' -- echo \'{{changed}}\'')

--- a/cli.js
+++ b/cli.js
@@ -32,16 +32,11 @@ if (!argv._.length || argv.help) {
 
 // Setup some storage variables
 var matches = argv._.slice()
-
-// Build exclusion list
-var exclude = typeof argv.exclude === 'boolean' ? [] : arrify(argv.exclude)
-
-// Shift first thing after to command and use the rest as args
 var args = argv['--'].slice()
 var command = args.shift()
 
 var options = {
-  exclude: exclude,
+  exclude: typeof argv.exclude === 'boolean' ? [] : arrify(argv.exclude),
   verbose: argv.verbose,
   initial: argv.initial,
   wait: argv.wait,
@@ -50,6 +45,7 @@ var options = {
   poll: argv.poll,
   killSignal: argv.killSignal,
   outpipe: argv.outpipe,
+  filter: argv.filter && (Array.isArray(argv.filter) ? argv.filter : argv.filter.split(/\W+/))
 }
 
 if (argv.filter) {

--- a/cli.js
+++ b/cli.js
@@ -16,7 +16,8 @@ var argv = require('minimist')(process.argv.slice(2), {
     cwd: ['c'],
     delay: ['d'],
     poll: ['p'],
-    outpipe: ['o']
+    outpipe: ['o'],
+    filter: ['f']
   },
   default: {
     exclude: '**/node_modules/**'
@@ -48,7 +49,11 @@ var options = {
   delay: argv.delay,
   poll: argv.poll,
   killSignal: argv.killSignal,
-  outpipe: argv.outpipe
+  outpipe: argv.outpipe,
+}
+
+if (argv.filter) {
+    options.filter = Array.isArray(argv.filter) ? argv.filter : argv.filter.split(/\W+/);
 }
 
 if (!command && !options.outpipe) {

--- a/index.d.ts
+++ b/index.d.ts
@@ -12,6 +12,7 @@ declare namespace onchange {
     stdout?: any;
     stderr?: any;
     outpipe?: string;
+    filter?: string[];
   }
 }
 

--- a/index.js
+++ b/index.js
@@ -18,6 +18,7 @@ module.exports = function (match, command, args, opts) {
   var delay = Number(opts.delay) || 0
   var killSignal = opts.killSignal || 'SIGTERM'
   var outpipe = typeof opts.outpipe === 'string' ? outpipetmpl(opts.outpipe) : undefined
+  var eventsToListen = opts.filter || ['all'];
 
   if (!command && !outpipe) {
     throw new TypeError('Expected "command" and/or "outpipe" to be specified')
@@ -165,9 +166,15 @@ module.exports = function (match, command, args, opts) {
       start({ event: '', changed: '' })
     }
 
+    var mustListenToAllEvents = eventsToListen.indexOf('all') >= 0;
+
     // For any change, creation or deletion, try to run.
     // Restart if the last run is still active.
     watcher.on('all', function (event, changed) {
+      if (!mustListenToAllEvents && eventsToListen.indexOf(event) === -1) {
+        return;
+      }
+
       // Log the event and the file affected
       log(event + ' to ' + changed)
 

--- a/index.js
+++ b/index.js
@@ -18,7 +18,7 @@ module.exports = function (match, command, args, opts) {
   var delay = Number(opts.delay) || 0
   var killSignal = opts.killSignal || 'SIGTERM'
   var outpipe = typeof opts.outpipe === 'string' ? outpipetmpl(opts.outpipe) : undefined
-  var filter = opts.filter || ['all'];
+  var filter = opts.filter || []
 
   if (!command && !outpipe) {
     throw new TypeError('Expected "command" and/or "outpipe" to be specified')

--- a/index.js
+++ b/index.js
@@ -18,7 +18,7 @@ module.exports = function (match, command, args, opts) {
   var delay = Number(opts.delay) || 0
   var killSignal = opts.killSignal || 'SIGTERM'
   var outpipe = typeof opts.outpipe === 'string' ? outpipetmpl(opts.outpipe) : undefined
-  var eventsToListen = opts.filter || ['all'];
+  var filter = opts.filter || ['all'];
 
   if (!command && !outpipe) {
     throw new TypeError('Expected "command" and/or "outpipe" to be specified')
@@ -166,14 +166,10 @@ module.exports = function (match, command, args, opts) {
       start({ event: '', changed: '' })
     }
 
-    var mustListenToAllEvents = eventsToListen.indexOf('all') >= 0;
-
     // For any change, creation or deletion, try to run.
     // Restart if the last run is still active.
     watcher.on('all', function (event, changed) {
-      if (!mustListenToAllEvents && eventsToListen.indexOf(event) === -1) {
-        return;
-      }
+      if (filter.length && filter.indexOf(event) === -1) return
 
       // Log the event and the file affected
       log(event + ' to ' + changed)


### PR DESCRIPTION
I have a special usecase where I need to track only `add` event with `onchange`, but the tool watches all events by default.

This PR adds the `--filter` argument to allow users to specific events they want to watch (it of course keeps `all` by default).

Let me know if it's OK for you :)