### PR TITLE
Add a warning about --exclude and node_modules

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,8 @@ To exclude matches (`**/node_modules/**` is excluded by default, use `--no-exclu
 onchange '**/*.ts' -e 'dist/**/*.js' -- tslint
 ```
 
+**P.S.** When you exclude something, it overrides the default, so if you want to keep `**/node_modules/**` excluded, then you need to add it to the command explicitly.
+
 ### Kill (`-k`, `--kill`)
 
 To kill current and pending processes between changes:


### PR DESCRIPTION
The docs are a bit confusing. Without knowing that this is Minimist-based, my interpretation was that `**/node_modules/**` remains ignored regardless of anything, unless I pass `--no-exclude`. This has resulted in `node_modules` being watched in a couple of projects, until the mistake has been pointed out by a person with fewer inotify slots than me.

Alternatively, for extra convenience, the disabling of the exclusion of `node_modules` could be given a special flag, like `--no-exclude-node-modules`, matching my original expectation.