### PR TITLE
NPM script interoperability : allow simple quotes in command arguments for Windows platform

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,8 +21,6 @@ onchange -i -k '**/*.js' -- node server.js
 onchange '**/*.js' -- echo '{{event}} to {{changed}}'
 ```
 
-NOTE: Windows users may need to use double quotes rather than single quotes. If used in an npm script, remember to escape the double quotes.
-
 You can match as many glob patterns as you like, just put the command you want to run after the `--` and it will run any time a file matching any of the globs is added changed or deleted.
 
 ## Options

--- a/index.js
+++ b/index.js
@@ -89,6 +89,12 @@ class Job {
 
 function onchange (match, command, rawArgs, opts = {}) {
   const matches = arrify(match)
+  // fix Windows simple quotes issue in NPM script
+  if (process.platform === 'win32') {
+    const filteredMatches = []
+    matches.forEach(str => filteredMatches.push(str.replace(/'/g, '')))
+    matches = filteredMatches
+  }
   const ready = opts.ready || (() => undefined)
   const initial = !!opts.initial
   const kill = !!opts.kill


### PR DESCRIPTION
- index.js:
	- check if process.platform is equal to 'win32' then:
	- remove generated simple quotes for each elements in matches
	array then:
	- update original matches array
- README.md:
	- remove text paragraph about Windows users and double quotes